### PR TITLE
Update babel-eslint dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "assert": "1.3.0",
     "babel": "^5.4.7",
     "babel-core": "^5.4.7",
-    "babel-eslint": "^3.1.23",
+    "babel-eslint": "^5.0.0",
     "babel-loader": "^5.0.0",
     "babel-plugin-dev-expression": "^0.1.0",
     "eslint": "1.4.1",


### PR DESCRIPTION
after npm install and npm run lint causes "TypeError: Cannot read property 'visitClass' of undefined".(https://github.com/babel/babel-eslint/issues/243) So updated it with the newest version.